### PR TITLE
Scraper resource name

### DIFF
--- a/docs/resources/itsi_kpi_threshold_template.md
+++ b/docs/resources/itsi_kpi_threshold_template.md
@@ -236,11 +236,14 @@ resource "itsi_kpi_threshold_template" "static" {
 
 - `adaptive_thresholding_training_window` (String)
 - `adaptive_thresholds_is_enabled` (Boolean)
-- `description` (String)
 - `sec_grp` (String)
 - `time_variate_thresholds` (Boolean)
 - `time_variate_thresholds_specification` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--time_variate_thresholds_specification))
 - `title` (String)
+
+### Optional
+
+- `description` (String)
 
 ### Read-Only
 
@@ -273,14 +276,14 @@ Optional:
 
 Required:
 
-- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
-- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `render_boundary_max` (Number) Upper bound value to use to render the graph for the thresholds.
 - `render_boundary_min` (Number) Lower bound value to use to render the graph for the thresholds.
 
 Optional:
 
 - `base_severity_label` (String)
+- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
+- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `is_max_static` (Boolean) True when maximum threshold value is a static value, false otherwise.
 - `is_min_static` (Boolean) True when min threshold value is a static value, false otherwise.
 - `metric_field` (String) Thresholding field from the search.
@@ -307,14 +310,14 @@ Optional:
 
 Required:
 
-- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
-- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `render_boundary_max` (Number) Upper bound value to use to render the graph for the thresholds.
 - `render_boundary_min` (Number) Lower bound value to use to render the graph for the thresholds.
 
 Optional:
 
 - `base_severity_label` (String)
+- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
+- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `is_max_static` (Boolean) True when maximum threshold value is a static value, false otherwise.
 - `is_min_static` (Boolean) True when min threshold value is a static value, false otherwise.
 - `metric_field` (String) Thresholding field from the search.

--- a/docs/resources/itsi_service.md
+++ b/docs/resources/itsi_service.md
@@ -162,14 +162,14 @@ Required:
 
 Required:
 
-- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
-- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `render_boundary_max` (Number) Upper bound value to use to render the graph for the thresholds.
 - `render_boundary_min` (Number) Lower bound value to use to render the graph for the thresholds.
 
 Optional:
 
 - `base_severity_label` (String)
+- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
+- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `is_max_static` (Boolean) True when maximum threshold value is a static value, false otherwise.
 - `is_min_static` (Boolean) True when min threshold value is a static value, false otherwise.
 - `metric_field` (String) Thresholding field from the search.
@@ -196,14 +196,14 @@ Optional:
 
 Required:
 
-- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
-- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `render_boundary_max` (Number) Upper bound value to use to render the graph for the thresholds.
 - `render_boundary_min` (Number) Lower bound value to use to render the graph for the thresholds.
 
 Optional:
 
 - `base_severity_label` (String)
+- `gauge_max` (Number) Maximum value for the threshold gauge specified by user
+- `gauge_min` (Number) Minimum value for the threshold gauge specified by user.
 - `is_max_static` (Boolean) True when maximum threshold value is a static value, false otherwise.
 - `is_min_static` (Boolean) True when min threshold value is a static value, false otherwise.
 - `metric_field` (String) Thresholding field from the search.

--- a/provider/abstract_resource_kpi_threshold.go
+++ b/provider/abstract_resource_kpi_threshold.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -143,12 +144,12 @@ func getKpiThresholdSettingsSchema() map[string]*schema.Schema {
 		},
 		"gauge_max": {
 			Type:        schema.TypeFloat,
-			Required:    true,
+			Optional:    true,
 			Description: "Maximum value for the threshold gauge specified by user",
 		},
 		"gauge_min": {
 			Type:        schema.TypeFloat,
-			Required:    true,
+			Optional:    true,
 			Description: "Minimum value for the threshold gauge specified by user.",
 		},
 		"is_max_static": {

--- a/provider/common.go
+++ b/provider/common.go
@@ -96,13 +96,8 @@ func (rt *resourceTemplate) escape(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	name = reg.ReplaceAllString(name, "-")
-	if strings.HasSuffix(name, "-") {
-		name = name[:len(name)-1]
-	}
-	if strings.HasPrefix(name, "-") {
-		name = name[1:]
-	}
+	name = reg.ReplaceAllString(name, "_")
+	name = strings.Trim(name, "_")
 	return name, nil
 }
 

--- a/provider/common.go
+++ b/provider/common.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"fmt"
 
@@ -98,6 +99,9 @@ func (rt *resourceTemplate) escape(name string) (string, error) {
 	}
 	name = reg.ReplaceAllString(name, "_")
 	name = strings.Trim(name, "_")
+	if unicode.IsDigit(rune(name[0])) {
+		name = fmt.Sprintf("_%s", name)
+	}
 	return name, nil
 }
 
@@ -132,6 +136,9 @@ func (rt *resourceTemplate) display(index string, element interface{}, sc *schem
 	if sc.Optional && sc.Default != nil && sc.Default == element {
 		return ""
 	}
+	if sc.Optional && sc.Default == nil && element == "" {
+		return ""
+	}
 	whitespaces := strings.Repeat("    ", ndepth)
 	suffix := whitespaces
 	mapSuffix := whitespaces
@@ -144,6 +151,9 @@ func (rt *resourceTemplate) display(index string, element interface{}, sc *schem
 	switch v.Kind() {
 
 	case reflect.String:
+		if sc.Optional && sc.Default != nil && v.String() == "" {
+			return ""
+		}
 		if strings.Contains(v.String(), "\n") {
 			split := strings.Split(v.String(), "\n")
 			for i := 0; i < len(split); i++ {

--- a/provider/resource_kpi_threshold_template.go
+++ b/provider/resource_kpi_threshold_template.go
@@ -65,7 +65,7 @@ func ResourceKPIThresholdTemplate() *schema.Resource {
 			},
 			"description": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"adaptive_thresholds_is_enabled": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
- fix the scraper to handle optional fields that are not set in a resource
- set a few fields from the KPI threshold template resource as optional