### PR TITLE
KPI base search: async update

### DIFF
--- a/models/base.go
+++ b/models/base.go
@@ -308,7 +308,7 @@ func (b *Base) updateAndWaitForState(ctx context.Context) (err error) {
 		return err
 	}
 
-	resultCh := make(chan error)
+	resultCh := make(chan error, 1)
 	go func() {
 		defer close(resultCh)
 		_, _, err := b.requestWithRetry(ctx, http.MethodPut, b.urlBaseWithKey(), reqBody)

--- a/provider/datasource_entity_type.go
+++ b/provider/datasource_entity_type.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -52,12 +51,7 @@ func entityTypeRead(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func populateEntityTypeResourceData(b *models.Base, d *schema.ResourceData) error {
-	by, err := b.RawJson.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	var interfaceMap map[string]interface{}
-	err = json.Unmarshal(by, &interfaceMap)
+	interfaceMap, err := b.RawJson.ToInterfaceMap()
 	if err != nil {
 		return err
 	}

--- a/provider/datasource_kpi_threshold_template.go
+++ b/provider/datasource_kpi_threshold_template.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,12 +41,7 @@ func DatasourceKPIThresholdTemplateRead(ctx context.Context, d *schema.ResourceD
 }
 
 func populateKPIThresholdTemplateDatasourceData(b *models.Base, d *schema.ResourceData) error {
-	by, err := b.RawJson.MarshalJSON()
-	if err != nil {
-		return err
-	}
-	var interfaceMap map[string]interface{}
-	err = json.Unmarshal(by, &interfaceMap)
+	interfaceMap, err := b.RawJson.ToInterfaceMap()
 	if err != nil {
 		return err
 	}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -104,7 +104,7 @@ func providerConfigure(c context.Context, d *schema.ResourceData) (interface{}, 
 		backoff.WithMaxRetries(0),
 	)
 
-	client.Concurrency = 10
+	client.Concurrency = 15
 	models.InitItsiApiLimiter(client.Concurrency)
 	InitSplunkSearchLimiter(client.Concurrency)
 	if os.Getenv("TF_LOG") == "true" {

--- a/provider/resource_entity.go
+++ b/provider/resource_entity.go
@@ -181,12 +181,7 @@ func entityRead(ctx context.Context, d *schema.ResourceData, m interface{}) (dia
 }
 
 func populateEntityResourceData(ctx context.Context, b *models.Base, d *schema.ResourceData) (diags diag.Diagnostics) {
-	by, err := b.RawJson.MarshalJSON()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	var interfaceMap map[string]interface{}
-	err = json.Unmarshal(by, &interfaceMap)
+	interfaceMap, err := b.RawJson.ToInterfaceMap()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/resource_kpi_base_search.go
+++ b/provider/resource_kpi_base_search.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-cty/cty"
 	"log"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
 
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -371,12 +372,7 @@ func kpiBaseSearchRead(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func populateBaseSearchResourceData(ctx context.Context, b *models.Base, d *schema.ResourceData) (diags diag.Diagnostics) {
-	by, err := b.RawJson.MarshalJSON()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	var interfaceMap map[string]interface{}
-	err = json.Unmarshal(by, &interfaceMap)
+	interfaceMap, err := b.RawJson.ToInterfaceMap()
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -448,7 +444,7 @@ func kpiBaseSearchUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return diag.FromErr(template.Update(ctx))
+	return diag.FromErr(template.UpdateAsync(ctx))
 }
 
 func kpiBaseSearchDelete(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {

--- a/provider/resource_kpi_threshold_template.go
+++ b/provider/resource_kpi_threshold_template.go
@@ -166,12 +166,7 @@ func kpiThresholdTemplateRead(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func populateKpiThresholdTemplateResourceData(ctx context.Context, b *models.Base, d *schema.ResourceData) (diags diag.Diagnostics) {
-	by, err := b.RawJson.MarshalJSON()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	var interfaceMap map[string]interface{}
-	err = json.Unmarshal(by, &interfaceMap)
+	interfaceMap, err := b.RawJson.ToInterfaceMap()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/scraper/main.go
+++ b/scraper/main.go
@@ -207,7 +207,7 @@ func auditLog(items []*models.Base, objectType, format string, formatter provide
 	case "json":
 		objects := []json.RawMessage{}
 		for _, item := range items {
-			objects = append(objects, item.RawJson)
+			objects = append(objects, json.RawMessage(item.RawJson))
 		}
 
 		by, err = json.MarshalIndent(objects, "", "  ")


### PR DESCRIPTION
handle kpi base search updates asynchronously (regular updates could timeout when KPI BS is linked to a big number of services and/or has many kpis)